### PR TITLE
Fix multiple bugs: ioctl buffer overflow, busy-spin loop, thread lifecycle, and more

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
-# shellsheck shell=bash
+# shellcheck shell=bash
 set -euo pipefail
 
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.7; then

--- a/analyze/analyze.go
+++ b/analyze/analyze.go
@@ -155,6 +155,7 @@ func formatGnuplotScript(prefix string, intervals []float64) string {
 		}
 	}
 
+	sanitizedPrefix := strings.NewReplacer(`"`, `\"`, `\`, `\\`).Replace(prefix)
 	fmt.Fprintf(&b, `set terminal svg size 800,600 font "monospace,12"
 set output "%s.svg"
 
@@ -172,7 +173,7 @@ set format x "%%g"
 
 # Data
 $data << EOD
-`, prefix, minMs*0.9, maxMs*1.1)
+`, sanitizedPrefix, minMs*0.9, maxMs*1.1)
 
 	// Output each interval with its index
 	for i, interval := range intervals {

--- a/linux/README.md
+++ b/linux/README.md
@@ -1,6 +1,6 @@
 # Jerkmon Linux Version
 
-Linux implementation of jerkmon using HIDRAW for raw mouse input capture.
+Linux implementation of jerkmon using evdev for raw mouse input capture.
 
 ## Building
 
@@ -10,7 +10,7 @@ cargo build --release
 
 ## Running
 
-The application requires access to hidraw devices and DRM devices, so you'll need to run with appropriate permissions:
+The application requires access to evdev input devices, so you'll need to run with appropriate permissions:
 
 ```bash
 sudo ./target/release/jerkmon
@@ -25,8 +25,8 @@ sudo usermod -a -G input,video $USER
 
 ## Features
 
-- Raw mouse input capture using HIDRAW devices
-- Display refresh monitoring using DRM vblank events
+- Raw mouse input capture using evdev devices
+- Display refresh monitoring using Wayland frame callbacks
 - WebSocket server on `127.0.0.1:12345` for event streaming
 - Binary protocol compatible with Windows version
 
@@ -46,8 +46,8 @@ Events are sent as binary messages:
 
 ## Notes
 
-- The Linux version uses HIDRAW to read raw HID reports from mouse devices
-- Display refresh uses real DRM vblank events from `/dev/dri/card0`
-- If DRM device cannot be opened or vblank monitoring fails, display events will not be reported
-- Multiple hidraw devices are monitored simultaneously
+- The Linux version uses evdev to read raw input events from mouse devices
+- Display refresh uses Wayland frame callbacks
+- If Wayland connection fails, display events will not be reported
+- Multiple evdev devices are monitored simultaneously, with hot-plug support via inotify
 - Ctrl+C for graceful shutdown

--- a/linux/src/evdev.rs
+++ b/linux/src/evdev.rs
@@ -22,8 +22,8 @@ const REL_Y: u16 = 0x01;
 // Input event structure matching kernel's input_event
 #[repr(C)]
 struct InputEvent {
-    tv_sec: i64,
-    tv_usec: i64,
+    tv_sec: u64,
+    tv_usec: u64,
     type_: u16,
     code: u16,
     value: i32,
@@ -32,6 +32,7 @@ struct InputEvent {
 pub fn start_monitors() -> Vec<JoinHandle<()>> {
     let mut threads = Vec::new();
     let active_devices = Arc::new(Mutex::new(HashSet::new()));
+    let hotplug_handles: Arc<Mutex<Vec<JoinHandle<()>>>> = Arc::new(Mutex::new(Vec::new()));
 
     // Start monitoring existing devices
     let devices = find_mouse_devices();
@@ -50,10 +51,22 @@ pub fn start_monitors() -> Vec<JoinHandle<()>> {
 
     // Start device discovery thread to watch for new devices
     let active_devices_clone = active_devices.clone();
+    let hotplug_handles_clone = hotplug_handles.clone();
     let discovery_handle = std::thread::spawn(move || {
-        device_discovery_thread(active_devices_clone);
+        device_discovery_thread(active_devices_clone, hotplug_handles_clone);
     });
     threads.push(discovery_handle);
+
+    // Join any hotplug threads on shutdown
+    let hotplug_join_handle = std::thread::spawn(move || {
+        utils::wait_for_shutdown();
+        if let Ok(mut handles) = hotplug_handles.lock() {
+            for handle in handles.drain(..) {
+                let _ = handle.join();
+            }
+        }
+    });
+    threads.push(hotplug_join_handle);
 
     threads
 }
@@ -114,7 +127,7 @@ fn is_mouse_device(fd: i32) -> bool {
     let mut rel_bits = [0u8; 2]; // 2 bytes = 16 bits, enough for REL_X and REL_Y
 
     unsafe {
-        const EVIOCGBIT_REL: u32 = 0x80044522; // _IOR('E', 0x22, char[2])
+        const EVIOCGBIT_REL: u32 = 0x80024522; // _IOR('E', 0x22, char[2])
         let result = libc::ioctl(fd, EVIOCGBIT_REL as _, rel_bits.as_mut_ptr());
 
         if result >= 0 {
@@ -229,7 +242,7 @@ fn send_mouse_event(x: f32, y: f32) {
     }
 }
 
-fn device_discovery_thread(active_devices: Arc<Mutex<HashSet<String>>>) {
+fn device_discovery_thread(active_devices: Arc<Mutex<HashSet<String>>>, hotplug_handles: Arc<Mutex<Vec<JoinHandle<()>>>>) {
     // Use inotify to watch for new devices in /dev/input
     let fd = unsafe { libc::inotify_init1(libc::IN_NONBLOCK) };
     if fd < 0 {
@@ -337,9 +350,10 @@ fn device_discovery_thread(active_devices: Arc<Mutex<HashSet<String>>>) {
                                         println!("New mouse detected: {}", device_path);
                                         let device_path_clone = device_path.clone();
                                         let active_devices_clone = active_devices.clone();
-                                        std::thread::spawn(move || {
+                                        let handle = std::thread::spawn(move || {
                                             let _ = monitor_device(&device_path_clone, active_devices_clone);
                                         });
+                                        hotplug_handles.lock().unwrap().push(handle);
                                     }
                                 }
                             }

--- a/linux/src/main.rs
+++ b/linux/src/main.rs
@@ -42,6 +42,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .set(Instant::now())
         .map_err(|_| "START_TIME already initialized")?;
 
+    ctrlc::set_handler(|| {
+        RUNNING.store(false, Ordering::Relaxed);
+    })?;
+
     // Start WebSocket server
     let ws_handle = std::thread::spawn(move || {
         let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
@@ -64,10 +68,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     let evdev_handles = evdev::start_monitors();
-
-    ctrlc::set_handler(|| {
-        RUNNING.store(false, Ordering::Relaxed);
-    })?;
 
     for handle in evdev_handles {
         let _ = handle.join();

--- a/linux/src/wayland.rs
+++ b/linux/src/wayland.rs
@@ -3,7 +3,7 @@
 //! Creates a minimal Wayland window to receive frame callbacks for display timing.
 
 use std::io::Write;
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsFd, AsRawFd};
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 
@@ -277,16 +277,32 @@ pub fn monitor_wayland_frames() -> Result<(), Box<dyn std::error::Error>> {
         surface.commit();
     }
 
-    // Event loop
+    // Event loop using poll to avoid busy-spinning
+    let wayland_fd = conn.as_fd();
+    let mut poll_fds = [libc::pollfd {
+        fd: std::os::unix::io::AsRawFd::as_raw_fd(&wayland_fd),
+        events: libc::POLLIN,
+        revents: 0,
+    }];
+
     while RUNNING.load(Ordering::Relaxed) {
+        event_queue.flush()?;
+
         if let Some(guard) = event_queue.prepare_read() {
-            let _ = guard.read();
+            let poll_result = unsafe { libc::poll(poll_fds.as_mut_ptr(), 1, 100) };
+            if poll_result > 0 {
+                let _ = guard.read();
+            } else {
+                guard.cancel();
+                if poll_result < 0 {
+                    return Err(std::io::Error::last_os_error().into());
+                }
+                continue;
+            }
         }
 
-        // Dispatch all pending events
         event_queue.dispatch_pending(&mut app_data)?;
 
-        // If no frame is pending, request one
         if !app_data.frame_pending && RUNNING.load(Ordering::Relaxed) {
             if let Some(surface) = &app_data.surface {
                 surface.frame(&qh, ());
@@ -294,8 +310,6 @@ pub fn monitor_wayland_frames() -> Result<(), Box<dyn std::error::Error>> {
                 surface.commit();
             }
         }
-
-        event_queue.flush()?;
     }
 
     Ok(())

--- a/win/src/main.rs
+++ b/win/src/main.rs
@@ -108,8 +108,18 @@ async fn websocket_server(rx: crossbeam_channel::Receiver<Vec<u8>>) {
 
     let (tx, mut rx_async) = tokio::sync::mpsc::unbounded_channel();
     std::thread::spawn(move || {
-        while let Ok(event) = rx.recv() {
-            let _ = tx.send(event);
+        loop {
+            match rx.recv_timeout(std::time::Duration::from_millis(100)) {
+                Ok(event) => {
+                    let _ = tx.send(event);
+                }
+                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
+                    if !RUNNING.load(Ordering::Relaxed) {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
         }
     });
 
@@ -347,9 +357,19 @@ fn start_vblank_thread(output: IDXGIOutput) {
         let mut last_vblank = Instant::now();
         const MIN_FRAME_TIME: std::time::Duration = std::time::Duration::from_micros(100);
 
+        let mut consecutive_errors = 0u32;
         while RUNNING.load(Ordering::Relaxed) {
             unsafe {
-                let _ = output.WaitForVBlank();
+                if output.WaitForVBlank().is_err() {
+                    consecutive_errors += 1;
+                    if consecutive_errors > 10 {
+                        eprintln!("Too many consecutive WaitForVBlank failures, stopping vblank thread");
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                    continue;
+                }
+                consecutive_errors = 0;
                 
                 // Capture timestamp immediately after vblank to minimize jitter
                 let timestamp = Instant::now();


### PR DESCRIPTION
## Summary

- **Fix stack buffer overflow in evdev ioctl**: The `EVIOCGBIT_REL` constant encoded a size of 4 bytes (`0x80044522`) but the target buffer is only 2 bytes. Corrected to `0x80024522` to prevent kernel writing past the buffer.
- **Fix `InputEvent` struct portability**: Changed `tv_sec` from `i64` to `u64` to match the kernel's `__kernel_ulong_t` (unsigned long) type.
- **Replace Wayland busy-spin with poll()**: The event loop was spinning at 100% CPU with no sleep or blocking. Now uses `poll()` with a 100ms timeout.
- **Track hot-plugged device threads**: Dynamically spawned monitor threads were never joined, causing them to be killed abruptly on shutdown. Now tracked via a shared `Vec<JoinHandle>` and joined on shutdown.
- **Register Ctrl-C handler before spawning threads**: Eliminates a race window where a signal between thread spawning and handler registration would use the default (abrupt termination) handler.
- **Handle `WaitForVBlank` errors on Windows**: Failed vblank waits were silently ignored, causing the thread to spin. Now tracks consecutive errors and breaks after 10 failures.
- **Fix Windows WebSocket bridge thread shutdown**: The bridge thread used blocking `rx.recv()` and never checked `RUNNING`. Now uses `recv_timeout` with a `RUNNING` check, matching the Linux implementation.
- **Update Linux README**: References to HIDRAW and DRM replaced with the actual evdev and Wayland implementation.
- **Fix `.envrc` typo**: `shellsheck` -> `shellcheck`.
- **Sanitize gnuplot prefix**: The `-curve` flag value is now escaped before interpolation into the gnuplot script.

## Test plan

- [ ] Verify Linux build compiles (`cargo build` in `linux/`)
- [ ] Verify Windows build compiles (`cargo build` in `win/`)
- [ ] Verify Go analysis tool compiles (`go build` in `analyze/`)
- [ ] Test mouse input monitoring works on Linux with evdev devices
- [ ] Test Wayland frame monitoring no longer pegs CPU
- [ ] Test Ctrl-C graceful shutdown
- [ ] Test hot-plug of mouse devices

Generated with [Indent](https://indent.com) - [session link](https://app.indent.com/chats/9a9926c3-5153-4a08-bec0-09f8ea2cf756)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level device I/O, polling, and thread lifecycle code on both Linux and Windows; changes should reduce crashes/CPU spin but could introduce platform-specific regressions if the new wait/poll logic misbehaves.
> 
> **Overview**
> Fixes several robustness issues across the Linux and Windows monitors, primarily around **unsafe syscalls and shutdown/CPU behavior**.
> 
> On Linux, corrects the `EVIOCGBIT` ioctl size (avoiding a potential buffer overflow), adjusts `InputEvent` timestamp fields for kernel portability, replaces the Wayland frame loop busy-spin with `poll()`-based waiting, and tracks/joins hot-plugged evdev monitor threads for clean shutdown; also registers the Ctrl-C handler earlier.
> 
> On Windows, prevents the WebSocket bridge thread from blocking indefinitely on shutdown, and adds error/backoff handling for repeated `WaitForVBlank` failures to avoid tight spinning. Separately, the Go analysis tool now escapes the `-curve` prefix before embedding it in the gnuplot script, and docs/config get small correctness updates (`linux/README.md`, `.envrc`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80e82875b428e90ac71bcc33d817f70eace00e25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->